### PR TITLE
jwt: scan requests, cookies, storage and URLs for JWTs

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,14 +14,12 @@ const jwts = {};
 
 // Request headers we're willing to look inside; matched case-insensitively.
 // Deliberately a short allow-list rather than every header, to keep false
-// positives down.
+// positives down. Cookie headers are deliberately left out: scanCookies reads
+// the jar directly, which gives real cookie names (a Cookie header only lists
+// name=value pairs we'd have to re-parse) and also sees HttpOnly cookies.
 const jwtRequestHeaders = new Set([
     "authorization",
     "proxy-authorization",
-    "cookie",
-]);
-const jwtResponseHeaders = new Set([
-    "set-cookie",
 ]);
 
 function freshJwts(tid) {
@@ -47,18 +45,31 @@ function originOf(url) {
     }
 }
 
+// A URL stripped to origin + pathname, dropping the query string. Header
+// locations point at a Network entry, which is identified by its path; the
+// query is not needed for that and a token can ride in a query parameter, so
+// keeping it would store the very token we promise never to keep.
+function pathOf(url) {
+    try {
+        const u = new URL(url);
+        return u.origin + u.pathname;
+    } catch (e) {
+        return url || "";
+    }
+}
+
 // Fold a found token into the tab's map, adding where it was seen to an
 // existing record rather than listing the same token twice. Only the
 // identifier, algorithm, bucket, and locations are kept -- never the token.
 // A location carries enough to point the user at it in DevTools: the source
 // kind, the header/cookie/storage name (where), and the request or page URL.
 //
-// Headers keep the full request URL: each request is a distinct, separately
-// inspectable Network entry. But a cookie rides on every request to its
-// domain, so keeping per-request URLs would list the same cookie dozens of
-// times over -- once per URL -- even though the popup only ever shows its
-// origin. So for cookies, storage, and the URL bar we reduce to the origin,
-// which collapses those to one row per name per origin.
+// Headers keep the request URL (minus its query, see pathOf): each request is
+// a distinct, separately inspectable Network entry. But a cookie rides on
+// every request to its domain, so keeping per-request URLs would list the same
+// cookie dozens of times over -- once per URL -- even though the popup only
+// ever shows its origin. So for cookies, storage, and the URL bar we reduce to
+// the origin, which collapses those to one row per name per origin.
 function recordJwt(tid, jwt, loc) {
     const map = freshJwts(tid);
     let rec = map.get(jwt.id);
@@ -72,9 +83,9 @@ function recordJwt(tid, jwt, loc) {
         };
         map.set(jwt.id, rec);
     }
-    const perRequest = loc.source === "req-header" ||
-                       loc.source === "resp-header";
-    if (!perRequest)
+    if (loc.source === "req-header")
+        loc = Object.assign({}, loc, { url: pathOf(loc.url) });
+    else
         loc = Object.assign({}, loc, { url: originOf(loc.url) });
     const dup = rec.sources.some(s =>
         s.source === loc.source && s.where === loc.where && s.url === loc.url);
@@ -113,17 +124,15 @@ async function scanCookies(tid, url) {
     }
 }
 
-// source is "req-header" or "resp-header"; a Cookie/Set-Cookie header is
-// relabelled "cookie" so the popup can point at the Cookies panel instead.
+// source is "req-header"; the token's location is the header it rode in.
 function scanHeaders(tid, headers, allow, source, url, detail) {
     if (!headers) return;
     for (const h of headers) {
         if (!allow.has(h.name.toLowerCase()))
             continue;
         for (const jwt of PQSpyJWT.scan(h.value)) {
-            const kind = /cookie/i.test(h.name) ? "cookie" : source;
             recordJwt(tid, jwt, {
-                source: kind,
+                source,
                 where: h.name,
                 url,
                 detail,
@@ -364,6 +373,7 @@ async function record(details) {
     if (tid < 0) return;
     if (details.type === "beacon")
         return;
+
     const info = await browser.webRequest.getSecurityInfo(
       details.requestId,
       {},
@@ -376,13 +386,6 @@ async function record(details) {
             nonpq: [],
             unknown: [],
         };
-    // A new top-level page is a new set of JWTs; the content script will
-    // re-report storage and URL tokens once it loads.
-    if (details.type === "main_frame")
-        jwts[tid] = new Map();
-
-    scanHeaders(tid, details.responseHeaders, jwtResponseHeaders,
-        "resp-header", details.url, details.method);
     let kex = info.keaGroupName;
     let tp;
     if (info.state === "insecure") {
@@ -428,17 +431,23 @@ async function logKex(details) {
 
 browser.webRequest.onHeadersReceived.addListener(logKex,
   {urls: ["*://*/*"]},
-  ["blocking", "responseHeaders"]
+  ["blocking"]
 );
 
-// Outgoing request headers carry the Authorization/Cookie tokens. Read-only
-// for our purposes, but the listener still has to be registered blocking to
-// be handed requestHeaders.
+// Outgoing request headers carry the Authorization tokens. Read-only for our
+// purposes, but the listener still has to be registered blocking to be handed
+// requestHeaders.
 browser.webRequest.onBeforeSendHeaders.addListener(function(details) {
     const tid = details.tabId;
     if (tid < 0 || details.type === "beacon")
         return;
     try {
+        // A new top-level page is a new set of JWTs; reset before scanning
+        // this request so the navigation's own Authorization header lands in
+        // the fresh map rather than being wiped by a later reset. The content
+        // script will re-report storage and URL tokens once it loads.
+        if (details.type === "main_frame")
+            jwts[tid] = new Map();
         scanHeaders(tid, details.requestHeaders, jwtRequestHeaders,
             "req-header", details.url, details.method);
     } catch (e) {
@@ -496,8 +505,10 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   // The popup's Rescan asks us to re-read the tab's cookie jar, which the
   // content script can't reach. Answer once the scan is done so the popup
-  // knows when to re-pull.
-  if (message.action === "jwt-rescan-cookies") {
+  // knows when to re-pull. This trusts message.tabId/message.url, so it must
+  // only come from the popup: a page's content script has a sender.tab and
+  // could otherwise steer cookie reads into another tab's map.
+  if (message.action === "jwt-rescan-cookies" && !sender.tab) {
     scanCookies(message.tabId, message.url).then(() => sendResponse(true));
     return true;
   }

--- a/background.js
+++ b/background.js
@@ -6,6 +6,132 @@
 // history, so there's every reason not to write them down.
 const kexes = {};
 
+// JWTs seen per tab, kept in memory only for the same reasons as kexes above.
+// Keyed by tab id, each a Map from a token's identifier to its record, so the
+// same token seen many times (every request resends its Authorization header)
+// collapses to one entry that just accrues more sources.
+const jwts = {};
+
+// Request headers we're willing to look inside; matched case-insensitively.
+// Deliberately a short allow-list rather than every header, to keep false
+// positives down.
+const jwtRequestHeaders = new Set([
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+]);
+const jwtResponseHeaders = new Set([
+    "set-cookie",
+]);
+
+function freshJwts(tid) {
+    if (!jwts[tid])
+        jwts[tid] = new Map();
+    return jwts[tid];
+}
+
+// How many distinct locations to keep per token before we stop adding more.
+// A chatty page can resend the same header on hundreds of requests; the popup
+// shows a "5+" hint once this is reached, so there's no value in growing the
+// list without bound.
+const maxSources = 5;
+
+// The origin of a URL, or the raw string if it doesn't parse. Cookies and web
+// storage belong to an origin's jar/area rather than to any one request, so
+// their locations are keyed and displayed by origin.
+function originOf(url) {
+    try {
+        return new URL(url).origin;
+    } catch (e) {
+        return url || "";
+    }
+}
+
+// Fold a found token into the tab's map, adding where it was seen to an
+// existing record rather than listing the same token twice. Only the
+// identifier, algorithm, bucket, and locations are kept -- never the token.
+// A location carries enough to point the user at it in DevTools: the source
+// kind, the header/cookie/storage name (where), and the request or page URL.
+//
+// Headers keep the full request URL: each request is a distinct, separately
+// inspectable Network entry. But a cookie rides on every request to its
+// domain, so keeping per-request URLs would list the same cookie dozens of
+// times over -- once per URL -- even though the popup only ever shows its
+// origin. So for cookies, storage, and the URL bar we reduce to the origin,
+// which collapses those to one row per name per origin.
+function recordJwt(tid, jwt, loc) {
+    const map = freshJwts(tid);
+    let rec = map.get(jwt.id);
+    if (!rec) {
+        rec = {
+            id: jwt.id,
+            alg: jwt.alg,
+            bucket: jwt.bucket,
+            sources: [],
+            more: false,
+        };
+        map.set(jwt.id, rec);
+    }
+    const perRequest = loc.source === "req-header" ||
+                       loc.source === "resp-header";
+    if (!perRequest)
+        loc = Object.assign({}, loc, { url: originOf(loc.url) });
+    const dup = rec.sources.some(s =>
+        s.source === loc.source && s.where === loc.where && s.url === loc.url);
+    if (dup)
+        return;
+    if (rec.sources.length >= maxSources) {
+        rec.more = true;
+        return;
+    }
+    rec.sources.push(loc);
+}
+
+// Read the tab's cookies straight from the cookie store and scan them. The
+// Cookie header is only seen when the browser actually sends a request, so a
+// page that's already loaded won't reveal its cookies to us again until it
+// makes one. This lets the popup's Rescan pick them up on demand, and unlike
+// document.cookie it also sees HttpOnly cookies -- which is where auth tokens
+// usually live.
+async function scanCookies(tid, url) {
+    if (!url)
+        return;
+    let cookies;
+    try {
+        cookies = await browser.cookies.getAll({ url });
+    } catch (e) {
+        console.error("PQSpy: could not read cookies", e);
+        return;
+    }
+    for (const c of cookies) {
+        for (const jwt of PQSpyJWT.scan(c.value))
+            recordJwt(tid, jwt, {
+                source: "cookie",
+                where: c.name,
+                url,
+            });
+    }
+}
+
+// source is "req-header" or "resp-header"; a Cookie/Set-Cookie header is
+// relabelled "cookie" so the popup can point at the Cookies panel instead.
+function scanHeaders(tid, headers, allow, source, url, detail) {
+    if (!headers) return;
+    for (const h of headers) {
+        if (!allow.has(h.name.toLowerCase()))
+            continue;
+        for (const jwt of PQSpyJWT.scan(h.value)) {
+            const kind = /cookie/i.test(h.name) ? "cookie" : source;
+            recordJwt(tid, jwt, {
+                source: kind,
+                where: h.name,
+                url,
+                detail,
+            });
+        }
+    }
+}
+
 function summarize(data) {
     const pq = data.pq.length;
     const npq = data.nonpq.length;
@@ -39,7 +165,7 @@ function summarize(data) {
 
 // Names come from getKeaGroupName() in nsNSSCallbacks.cpp; which of them
 // Firefox offers is set by namedGroups in nsNSSIOLayer.cpp.
-function classify(kex) {
+function classifyKex(kex) {
     switch (kex) {
         case "mlkem768x25519":
         case "mlkem1024":
@@ -59,6 +185,9 @@ function classify(kex) {
             return "unknown";
     }
 }
+
+// JWT algorithm classification lives in jwt.js (PQSpyJWT.classifySig), shared
+// with the content script.
 
 // Order the wedges are drawn in, clockwise from twelve o'clock. Muted, so
 // they don't drown out the atom drawn on top of them.
@@ -247,6 +376,13 @@ async function record(details) {
             nonpq: [],
             unknown: [],
         };
+    // A new top-level page is a new set of JWTs; the content script will
+    // re-report storage and URL tokens once it loads.
+    if (details.type === "main_frame")
+        jwts[tid] = new Map();
+
+    scanHeaders(tid, details.responseHeaders, jwtResponseHeaders,
+        "resp-header", details.url, details.method);
     let kex = info.keaGroupName;
     let tp;
     if (info.state === "insecure") {
@@ -256,7 +392,7 @@ async function record(details) {
         // Serialised into the cache entry along with the rest of the security
         // info, so a cached response says as much about the connection it
         // first arrived on as a fresh one does.
-        tp = classify(kex);
+        tp = classifyKex(kex);
     } else {
         // No group to report: a resumed TLS session, for one. Encrypted, but
         // we can't say with what.
@@ -292,25 +428,77 @@ async function logKex(details) {
 
 browser.webRequest.onHeadersReceived.addListener(logKex,
   {urls: ["*://*/*"]},
-  ["blocking"]
+  ["blocking", "responseHeaders"]
+);
+
+// Outgoing request headers carry the Authorization/Cookie tokens. Read-only
+// for our purposes, but the listener still has to be registered blocking to
+// be handed requestHeaders.
+browser.webRequest.onBeforeSendHeaders.addListener(function(details) {
+    const tid = details.tabId;
+    if (tid < 0 || details.type === "beacon")
+        return;
+    try {
+        scanHeaders(tid, details.requestHeaders, jwtRequestHeaders,
+            "req-header", details.url, details.method);
+    } catch (e) {
+        console.error("PQSpy: could not scan request headers", e);
+    }
+  },
+  {urls: ["*://*/*"]},
+  ["blocking", "requestHeaders"]
 );
 
 browser.tabs.onRemoved.addListener(function(tid, info) {
     delete kexes[tid];
+    delete jwts[tid];
 });
 
 // The icon set while the main frame's headers were in flight gets dropped
 // again when the navigation commits. Usually a subresource comes along and
 // sets it back, but a page that requests nothing else -- an image opened on
 // its own, say -- would be left showing the default.
-browser.tabs.onUpdated.addListener(function(tid, info) {
-    if (info.status !== "complete" || !kexes[tid])
+browser.tabs.onUpdated.addListener(function(tid, info, tab) {
+    if (info.status !== "complete")
         return;
-    showIcon(tid, summarize(kexes[tid])[0], kexes[tid]);
+    // Read the cookie jar once the page has settled, so cookie JWTs show up
+    // without waiting for the next request to resend the Cookie header.
+    if (tab && tab.url)
+        scanCookies(tid, tab.url);
+    if (kexes[tid])
+        showIcon(tid, summarize(kexes[tid])[0], kexes[tid]);
 });
 
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "pqspy") {
-    sendResponse(kexes[message.tabId]);
+    const data = kexes[message.tabId] || null;
+    const list = jwts[message.tabId]
+        ? [...jwts[message.tabId].values()]
+        : [];
+    // Widen the encryption response with the tab's JWTs so the popup only
+    // makes one round-trip. kexes[] may be undefined for an unseen tab; the
+    // popup already copes with that.
+    sendResponse(Object.assign({ jwts: list }, data));
+    return;
+  }
+
+  // Findings from the content script (web storage and the URL fragment),
+  // already decoded there so tokens never cross the boundary. The sender's
+  // tab is authoritative -- don't trust a tab id from the message.
+  if (message.action === "jwt-report" && sender.tab) {
+    for (const f of message.found || []) {
+        if (f && f.id && f.alg)
+            recordJwt(sender.tab.id,
+                { id: f.id, alg: f.alg, bucket: f.bucket },
+                { source: f.source, where: f.where, url: f.url });
+    }
+  }
+
+  // The popup's Rescan asks us to re-read the tab's cookie jar, which the
+  // content script can't reach. Answer once the scan is done so the popup
+  // knows when to re-pull.
+  if (message.action === "jwt-rescan-cookies") {
+    scanCookies(message.tabId, message.url).then(() => sendResponse(true));
+    return true;
   }
 });

--- a/content.js
+++ b/content.js
@@ -8,8 +8,11 @@
 (function () {
     function report(found) {
         if (!found.length)
-            return;
-        browser.runtime.sendMessage({ action: "jwt-report", found })
+            return Promise.resolve();
+        // Returned so callers can await the report reaching the background.
+        // The background's jwt-report handler is synchronous, so once this
+        // resolves the findings are recorded.
+        return browser.runtime.sendMessage({ action: "jwt-report", found })
             .catch(() => {
                 // Background may be momentarily unavailable; nothing to do.
             });
@@ -57,15 +60,16 @@
         try { fromStorage(localStorage, "localStorage", found); } catch (e) {}
         try { fromStorage(sessionStorage, "sessionStorage", found); } catch (e) {}
         fromUrl(found);
-        report(found);
+        return report(found);
     }
 
     scan();
 
-    // The popup's Rescan button reaches the page through here, since storage
-    // written after load isn't observable from the same document otherwise.
+    // Returning the scan's promise makes tabs.sendMessage in the popup resolve
+    // only once the report has reached the background, so the popup can pull
+    // fresh data without racing the report.
     browser.runtime.onMessage.addListener((message) => {
         if (message && message.action === "jwt-rescan")
-            scan();
+            return scan();
     });
 })();

--- a/content.js
+++ b/content.js
@@ -1,0 +1,71 @@
+"use strict";
+
+// Runs in the page to reach the two places the background can't see: web
+// storage and the URL fragment (the part after #, which is never sent to the
+// server). Tokens are decoded here via the shared jwt.js and only their
+// identifier, algorithm, and location are sent on -- the token itself never
+// leaves the page.
+(function () {
+    function report(found) {
+        if (!found.length)
+            return;
+        browser.runtime.sendMessage({ action: "jwt-report", found })
+            .catch(() => {
+                // Background may be momentarily unavailable; nothing to do.
+            });
+    }
+
+    function fromStorage(store, source, found) {
+        let n;
+        try {
+            n = store.length;
+        } catch (e) {
+            // Storage can be blocked (e.g. by cookie policy); skip quietly.
+            return;
+        }
+        for (let i = 0; i < n; i++) {
+            const key = store.key(i);
+            let value;
+            try {
+                value = store.getItem(key);
+            } catch (e) {
+                continue;
+            }
+            // The key itself occasionally holds the token, so scan both.
+            for (const jwt of PQSpyJWT.scan(key + " " + value))
+                found.push({ id: jwt.id, alg: jwt.alg, bucket: jwt.bucket,
+                             source, where: key, url: location.href });
+        }
+    }
+
+    function fromUrl(found) {
+        // Split query and fragment so the popup can say which one, and so the
+        // fragment (never sent to the server, so only visible here) is called
+        // out as such. location.search / location.hash keep the leading ? / #.
+        const parts = [
+            ["query", location.search],
+            ["fragment", location.hash],
+        ];
+        for (const [where, text] of parts)
+            for (const jwt of PQSpyJWT.scan(text))
+                found.push({ id: jwt.id, alg: jwt.alg, bucket: jwt.bucket,
+                             source: "url", where, url: location.href });
+    }
+
+    function scan() {
+        const found = [];
+        try { fromStorage(localStorage, "localStorage", found); } catch (e) {}
+        try { fromStorage(sessionStorage, "sessionStorage", found); } catch (e) {}
+        fromUrl(found);
+        report(found);
+    }
+
+    scan();
+
+    // The popup's Rescan button reaches the page through here, since storage
+    // written after load isn't observable from the same document otherwise.
+    browser.runtime.onMessage.addListener((message) => {
+        if (message && message.action === "jwt-rescan")
+            scan();
+    });
+})();

--- a/jwt.js
+++ b/jwt.js
@@ -1,0 +1,111 @@
+"use strict";
+
+// Shared by the background page and the content script. Loaded as a plain
+// script in both, so everything here hangs off a single global to avoid
+// leaking names into the page the content script runs in.
+const PQSpyJWT = (function () {
+    // The header of every JWT is base64url("{"...), which always begins
+    // "eyJ". Three dot-separated base64url segments; the signature (third)
+    // may be empty for unsigned tokens. Kept deliberately loose -- decode()
+    // is the real filter, this only finds candidates to hand it.
+    const CANDIDATE = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*/g;
+
+    // Names as they appear in a JWT header's "alg". These match the JOSE
+    // registry, which is also what Firefox reports, so no translation needed.
+    function classifySig(alg) {
+        switch (alg) {
+            case "ML-DSA-44":
+            case "ML-DSA-65":
+            case "ML-DSA-87":
+            case "HS256":
+            case "HS384":
+            case "HS512":
+                return "pq";
+            case "RS256":
+            case "RS384":
+            case "RS512":
+            case "ES256":
+            case "ES384":
+            case "ES512":
+            case "PS256":
+            case "PS384":
+            case "PS512":
+            case "EdDSA":
+            case "Ed25519":
+            case "Ed448":
+                return "nonpq";
+            default:
+                return "unknown";
+        }
+    }
+
+    // base64url -> string, tolerant of missing padding. Returns null on
+    // anything that doesn't decode, so callers can treat it as "not a JWT".
+    function b64urlToString(seg) {
+        try {
+            let b64 = seg.replace(/-/g, "+").replace(/_/g, "/");
+            while (b64.length % 4)
+                b64 += "=";
+            return atob(b64);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // A short, stable identifier so the popup can tell tokens apart and we can
+    // de-duplicate, without ever keeping the token itself. Uses the tail of
+    // the signature, which is high-entropy and reveals nothing decodable. An
+    // unsigned token (empty signature) has none, so fall back to the payload
+    // tail there.
+    function identify(token) {
+        const parts = token.split(".");
+        const sig = parts[2] || "";
+        const src = sig.length >= 4 ? sig : (parts[1] || "");
+        return src.slice(-8) || "unknown";
+    }
+
+    // Decode a single candidate into { id, alg, bucket }, or null if it isn't
+    // actually a JWT. Requires a parseable header object carrying an "alg":
+    // that's what rules out random "eyJ..."-looking strings.
+    function decode(token) {
+        const parts = token.split(".");
+        if (parts.length < 2)
+            return null;
+        const headerJson = b64urlToString(parts[0]);
+        if (headerJson === null)
+            return null;
+        let header;
+        try {
+            header = JSON.parse(headerJson);
+        } catch (e) {
+            return null;
+        }
+        if (!header || typeof header !== "object" || !("alg" in header))
+            return null;
+        const alg = String(header.alg);
+        return { id: identify(token), alg, bucket: classifySig(alg) };
+    }
+
+    // Pull every JWT out of an arbitrary string (a header value, cookie jar,
+    // URL, or storage entry), decoded and de-duplicated by id.
+    function scan(text) {
+        const out = new Map();
+        if (!text)
+            return [];
+        const matches = String(text).match(CANDIDATE);
+        if (!matches)
+            return [];
+        for (const m of matches) {
+            const jwt = decode(m);
+            if (jwt && !out.has(jwt.id))
+                out.set(jwt.id, jwt);
+        }
+        return [...out.values()];
+    }
+
+    return { classifySig, decode, identify, scan };
+})();
+
+// Make it reachable when loaded via importScripts/background too.
+if (typeof globalThis !== "undefined")
+    globalThis.PQSpyJWT = PQSpyJWT;

--- a/jwt.js
+++ b/jwt.js
@@ -82,6 +82,13 @@ const PQSpyJWT = (function () {
         }
         if (!header || typeof header !== "object" || !("alg" in header))
             return null;
+        // A five-segment JWE also starts with three base64url segments, so
+        // CANDIDATE matches its first three and the header parses -- but its
+        // "alg" names a key-management scheme, not a signature. The "enc"
+        // member is what marks it a JWE; skip those, we only classify the
+        // signatures of signed JWTs (JWS).
+        if ("enc" in header)
+            return null;
         const alg = String(header.alg);
         return { id: identify(token), alg, bucket: classifySig(alg) };
     }

--- a/manifest.json
+++ b/manifest.json
@@ -10,10 +10,18 @@
     "default_title": "PQSpy",
     "default_popup": "popup.html"
   },
-  "permissions": ["tabs", "webRequest", "webRequestBlocking", "<all_urls>"],
+  "permissions": ["tabs", "cookies", "webRequest", "webRequestBlocking", "<all_urls>"],
   "background": {
-    "scripts": [ "background.js" ]
+    "scripts": [ "jwt.js", "background.js" ]
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": [ "jwt.js", "content.js" ],
+      "run_at": "document_idle",
+      "all_frames": false
+    }
+  ],
   "icons": {
     "114": "icons/yes.png"
   },

--- a/popup.css
+++ b/popup.css
@@ -35,6 +35,47 @@ summary {
     color: var(--cached);
 }
 
+#jwt-bar {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+}
+
+#jwt-summary {
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+#jwt-rescan {
+    font: inherit;
+    font-size: 0.8rem;
+    cursor: pointer;
+    background: none;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 0.1rem 0.5rem;
+}
+
+.jwt-id {
+    font-family: monospace;
+    color: var(--footnote);
+}
+
+/* The per-token location trails, nested under each JWT list item. */
+ul.jwt-locs {
+    list-style: none;
+    padding-left: 0;
+    margin: 0.15rem 0 0.35rem;
+}
+
+.jwt-more {
+    color: var(--footnote);
+    font-style: italic;
+}
+
 ul {
     font-size: 0.8rem;
     line-height: 1.2;
@@ -71,7 +112,33 @@ li .url:hover {
     margin-bottom: 0.5rem;
 }
 
-#caveat {
+/* Tab strip across the top; sits on the same rule the footers use below. */
+#tabs {
+    display: flex;
+    gap: 0.25rem;
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid var(--rule);
+}
+
+.tab {
+    font: inherit;
+    font-size: 0.95rem;
+    cursor: pointer;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--footnote);
+    padding: 0.35rem 0.6rem;
+    margin-bottom: -1px;
+}
+
+.tab.active {
+    color: var(--text);
+    font-weight: 600;
+    border-bottom-color: var(--text);
+}
+
+#caveat, #jwt-caveat {
     font-size: 0.8rem;
     line-height: 1.4;
     margin-top: 1rem;
@@ -80,9 +147,17 @@ li .url:hover {
     color: var(--footnote);
 }
 
+/* The JWT tab has nothing above its footer yet, so drop the top margin that
+   would otherwise leave it floating below the tab strip. */
+#panel-jwts #jwt-caveat {
+    margin-top: 0;
+    border-top: none;
+    padding-top: 0;
+}
+
 /* Inherited rather than the default link blue, which is unreadable on the
    dark background. */
-#caveat a {
+#caveat a, #jwt-caveat a {
     color: inherit;
     text-decoration: underline;
 }

--- a/popup.css
+++ b/popup.css
@@ -36,27 +36,12 @@ summary {
 }
 
 #jwt-bar {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 0.5rem;
     margin-bottom: 0.25rem;
 }
 
 #jwt-summary {
     font-size: 1.15rem;
     font-weight: 600;
-}
-
-#jwt-rescan {
-    font: inherit;
-    font-size: 0.8rem;
-    cursor: pointer;
-    background: none;
-    border: 1px solid var(--rule);
-    border-radius: 4px;
-    color: var(--text);
-    padding: 0.1rem 0.5rem;
 }
 
 .jwt-id {

--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,15 @@
   </head>
 
   <body>
+      <div id="tabs" role="tablist">
+      <button id="tab-encryption" class="tab active" role="tab"
+              aria-selected="true" aria-controls="panel-encryption">Encryption</button>
+      <button id="tab-jwts" class="tab" role="tab"
+              aria-selected="false" aria-controls="panel-jwts">JWTs</button>
+      </div>
+
+      <section id="panel-encryption" class="panel" role="tabpanel"
+               aria-labelledby="tab-encryption">
       <div id="summary">Waiting for data ...</div>
       <div id="page" class="hidden">❌ the page itself is not post-quantum encrypted</div>
 
@@ -49,6 +58,39 @@
       <a href="https://github.com/bwesterb/pqspy/issues/4"
          target="_blank">yet</a>.
       </footer>
+      </section>
+
+      <section id="panel-jwts" class="panel hidden" role="tabpanel"
+               aria-labelledby="tab-jwts">
+      <div id="jwt-bar">
+        <span id="jwt-summary">Waiting for data ...</span>
+        <button id="jwt-rescan" type="button">Rescan</button>
+      </div>
+
+      <details id="jwt-pq" class="hidden">
+      <summary><span class="counter">?</span> ⚛️  post-quantum secure</summary>
+      <ul></ul>
+      </details>
+
+      <details id="jwt-not-pq" class="hidden">
+      <summary><span class="counter">?</span> ❌ not post-quantum secure</summary>
+      <ul></ul>
+      </details>
+
+      <details id="jwt-unknown" class="hidden">
+      <summary><span class="counter">?</span> ❓ unknown</summary>
+      <ul></ul>
+      </details>
+
+      <footer id="jwt-caveat">
+      This tab reports the
+      <a href="https://en.wikipedia.org/wiki/JSON_Web_Token"
+         target="_blank">JSON Web Tokens</a> seen in this tab's request and
+      response headers, cookies, URL, and web storage, classified by whether
+      their signature algorithm is post-quantum secure. Headers update
+      live; use Rescan to re-read the page's storage and URL.
+      </footer>
+      </section>
 
       <script src="popup.js"></script>
   </body>

--- a/popup.html
+++ b/popup.html
@@ -64,7 +64,6 @@
                aria-labelledby="tab-jwts">
       <div id="jwt-bar">
         <span id="jwt-summary">Waiting for data ...</span>
-        <button id="jwt-rescan" type="button">Rescan</button>
       </div>
 
       <details id="jwt-pq" class="hidden">
@@ -85,10 +84,8 @@
       <footer id="jwt-caveat">
       This tab reports the
       <a href="https://en.wikipedia.org/wiki/JSON_Web_Token"
-         target="_blank">JSON Web Tokens</a> seen in this tab's request and
-      response headers, cookies, URL, and web storage, classified by whether
-      their signature algorithm is post-quantum secure. Headers update
-      live; use Rescan to re-read the page's storage and URL.
+         target="_blank">JSON Web Tokens</a> seen in this tab's request
+      headers, cookies, URL, and web storage.
       </footer>
       </section>
 

--- a/popup.js
+++ b/popup.js
@@ -57,9 +57,6 @@ function describe(s) {
         case "req-header":
             return "Network \u25b8 " + s.url +
                    " \u25b8 Request Headers \u25b8 " + s.where;
-        case "resp-header":
-            return "Network \u25b8 " + s.url +
-                   " \u25b8 Response Headers \u25b8 " + s.where;
         case "url":
             return "URL \u25b8 " + s.where;
         default:
@@ -191,36 +188,39 @@ async function pull() {
 
 // Ask the active tab's content script to re-read its storage and URL, and the
 // background to re-read the tab's cookie jar (which the content script can't
-// reach), then pull the refreshed data.
-function setupRescan() {
-    document.querySelector("#jwt-rescan").addEventListener("click", async () => {
-        const tabs = await browser.tabs.query({
-            active: true,
-            currentWindow: true,
-        });
-        const tid = tabs[0].id;
-
-        // Cookies: handled in the background, which replies when done.
-        const cookies = browser.runtime.sendMessage({
-            action: "jwt-rescan-cookies",
-            tabId: tid,
-            url: tabs[0].url,
-        }).catch(() => {});
-
-        // Storage and URL: handled by the content script, which reports back
-        // asynchronously, so give it a moment before re-pulling.
-        try {
-            await browser.tabs.sendMessage(tid, { action: "jwt-rescan" });
-        } catch (e) {
-            // No content script on this page (e.g. about: pages); nothing to
-            // rescan there, just refresh from what the background has.
-        }
-
-        await cookies;
-        setTimeout(pull, 150);
+// reach), then pull the refreshed data. Run on popup open so the JWT view is
+// fresh without the user having to ask for it.
+async function rescan() {
+    const tabs = await browser.tabs.query({
+        active: true,
+        currentWindow: true,
     });
+    const tid = tabs[0].id;
+
+    // Cookies: handled in the background, which replies when done.
+    const cookies = browser.runtime.sendMessage({
+        action: "jwt-rescan-cookies",
+        tabId: tid,
+        url: tabs[0].url,
+    }).catch(() => {});
+
+    // Storage and URL: handled by the content script. Its listener
+    // returns the report's promise, so awaiting sendMessage here waits
+    // until the findings have reached the background (whose handler is
+    // synchronous) -- no need to guess with a timer.
+    try {
+        await browser.tabs.sendMessage(tid, { action: "jwt-rescan" });
+    } catch (e) {
+        // No content script on this page (e.g. about: pages); nothing to
+        // rescan there, just refresh from what the background has.
+    }
+
+    await cookies;
+    await pull();
 }
 
 setupTabs();
-setupRescan();
+// Paint immediately from what the background already has, then kick off a
+// rescan whose own pull() lands a moment later with fresh storage/URL/cookies.
 pull();
+rescan();

--- a/popup.js
+++ b/popup.js
@@ -29,10 +29,111 @@ function fill(sel, entries) {
     }
 }
 
+// The origin part of a URL, for the Storage panel breadcrumbs which are keyed
+// by origin. Falls back to the raw string if it doesn't parse.
+function originOf(url) {
+    try {
+        return new URL(url).origin;
+    } catch (e) {
+        return url || "";
+    }
+}
+
+// A location -> the DevTools trail we show pointing at where the token lives.
+// We can't open DevTools from here -- no API for it -- so this is a pointer,
+// not a jump.
+function describe(s) {
+    const origin = originOf(s.url);
+    switch (s.source) {
+        case "localStorage":
+            return "Storage \u25b8 Local Storage \u25b8 " + origin +
+                   " \u25b8 " + s.where;
+        case "sessionStorage":
+            return "Storage \u25b8 Session Storage \u25b8 " + origin +
+                   " \u25b8 " + s.where;
+        case "cookie":
+            return "Storage \u25b8 Cookies \u25b8 " + origin +
+                   " \u25b8 " + s.where;
+        case "req-header":
+            return "Network \u25b8 " + s.url +
+                   " \u25b8 Request Headers \u25b8 " + s.where;
+        case "resp-header":
+            return "Network \u25b8 " + s.url +
+                   " \u25b8 Response Headers \u25b8 " + s.where;
+        case "url":
+            return "URL \u25b8 " + s.where;
+        default:
+            return s.source + " \u25b8 " + s.where;
+    }
+}
+
+// Render one bucket of JWTs. Mirrors fill() above, but the entries carry no
+// token -- only the identifier, algorithm, and where each was seen.
+function fillJwt(sel, entries) {
+    document.querySelector(sel + " .counter").innerText = entries.length;
+    document.querySelector(sel).classList.toggle("hidden", entries.length == 0);
+    let ul = document.querySelector(sel + " ul");
+    ul.innerHTML = "";
+    for (let entry of entries) {
+        let li = document.createElement("li");
+        let salg = document.createElement("span");
+        salg.classList.add("kex");
+        salg.innerText = entry.alg;
+        let sid = document.createElement("span");
+        sid.classList.add("jwt-id");
+        sid.innerText = "#" + entry.id;
+        li.append(salg);
+        li.appendChild(document.createTextNode(" "));
+        li.append(sid);
+
+        let locs = document.createElement("ul");
+        locs.classList.add("jwt-locs");
+        for (const s of entry.sources) {
+            let lli = document.createElement("li");
+            let scrumb = document.createElement("span");
+            scrumb.classList.add("url");
+            scrumb.innerText = describe(s);
+            lli.append(scrumb);
+            locs.appendChild(lli);
+        }
+        if (entry.more) {
+            let lli = document.createElement("li");
+            lli.classList.add("jwt-more");
+            lli.innerText = "5+ more locations";
+            locs.appendChild(lli);
+        }
+        li.append(locs);
+        ul.appendChild(li);
+    }
+}
+
+function updateJwts(list) {
+    list = list || [];
+    const pq = list.filter(j => j.bucket === "pq");
+    const nonpq = list.filter(j => j.bucket === "nonpq");
+    const unknown = list.filter(j => j.bucket === "unknown");
+
+    const summary = list.length == 0
+        ? "No JWTs seen"
+        : list.length + (list.length == 1 ? " JWT seen" : " JWTs seen");
+    document.querySelector("#jwt-summary").innerText = summary;
+
+    fillJwt("#jwt-pq", pq);
+    fillJwt("#jwt-not-pq", nonpq);
+    fillJwt("#jwt-unknown", unknown);
+}
+
 function update(data, tabId) {
     // Undefined for tabs the background script hasn't seen requests for,
-    // for instance after it was restarted.
-    data = data || { summary: "No resources", pq: [], nonpq: [], unknown: [] };
+    // for instance after it was restarted. The encryption fields can also be
+    // absent while JWTs are present -- a tab whose only finding came from the
+    // content script -- so fill in defaults per field rather than wholesale.
+    data = data || {};
+    data = Object.assign({
+        summary: "No resources",
+        pq: [], nonpq: [], unknown: [],
+        jwts: [],
+    }, data);
 
     document.querySelector("#summary").innerText = data.summary;
 
@@ -50,18 +151,76 @@ function update(data, tabId) {
     fill("#not-pq-cached", cached(data.nonpq));
     fill("#unknown", fresh(data.unknown));
     fill("#unknown-cached", cached(data.unknown));
+
+    updateJwts(data.jwts);
 }
 
-async function pull() {
+// Toggle which panel is shown. The verdict keeps updating in the background
+// either way; only its visibility changes.
+function setupTabs() {
+    const tabs = document.querySelectorAll(".tab");
+    for (const tab of tabs) {
+        tab.addEventListener("click", () => {
+            for (const other of tabs) {
+                const on = other === tab;
+                other.classList.toggle("active", on);
+                other.setAttribute("aria-selected", on);
+                document.getElementById(
+                    other.getAttribute("aria-controls"))
+                    .classList.toggle("hidden", !on);
+            }
+        });
+    }
+}
+
+async function activeTabId() {
     const tabs = await browser.tabs.query({
         active: true,
         currentWindow: true,
     });
-    const tid = tabs[0].id;
+    return tabs[0].id;
+}
+
+async function pull() {
+    const tid = await activeTabId();
     update(await browser.runtime.sendMessage({
         action: "pqspy",
         tabId: tid,
     }), tid);
 }
 
+// Ask the active tab's content script to re-read its storage and URL, and the
+// background to re-read the tab's cookie jar (which the content script can't
+// reach), then pull the refreshed data.
+function setupRescan() {
+    document.querySelector("#jwt-rescan").addEventListener("click", async () => {
+        const tabs = await browser.tabs.query({
+            active: true,
+            currentWindow: true,
+        });
+        const tid = tabs[0].id;
+
+        // Cookies: handled in the background, which replies when done.
+        const cookies = browser.runtime.sendMessage({
+            action: "jwt-rescan-cookies",
+            tabId: tid,
+            url: tabs[0].url,
+        }).catch(() => {});
+
+        // Storage and URL: handled by the content script, which reports back
+        // asynchronously, so give it a moment before re-pulling.
+        try {
+            await browser.tabs.sendMessage(tid, { action: "jwt-rescan" });
+        } catch (e) {
+            // No content script on this page (e.g. about: pages); nothing to
+            // rescan there, just refresh from what the background has.
+        }
+
+        await cookies;
+        setTimeout(pull, 150);
+    });
+}
+
+setupTabs();
+setupRescan();
 pull();


### PR DESCRIPTION
<img width="1457" height="1046" alt="Screenshot 2026-08-06 at 15 27 18" src="https://github.com/user-attachments/assets/dcccb25f-ce1d-4fa7-95e5-9b6e443bbe09" />

Adds a JWTs tab to the popup that finds JSON Web Tokens (in request/response headers, cookies, localStorage/sessionStorage, and the URL) and classifies each whether the signature algorithm is post-quantum.